### PR TITLE
rename incorrect uses of "sample" => "frame"

### DIFF
--- a/src/midi.zig
+++ b/src/midi.zig
@@ -10,7 +10,7 @@ pub const Note = struct {
     note: u8,
 };
 
-pub fn beatsToSamples(beats: f32, tempo: f32, ctx: *audio.Context) Frame {
+pub fn beatsToFrames(beats: f32, tempo: f32, ctx: *audio.Context) Frame {
     return @intFromFloat((60.0 / tempo) * ctx.sample_rate * beats);
 }
 
@@ -29,13 +29,13 @@ pub const Player = struct {
     pub fn deinit(self: *Player, alloc: std.mem.Allocator) void {
         alloc.free(self.notes);
     }
-    pub fn advance(self: *Player, samples_elapsed: u64, q: *synth.NoteQueue) void {
+    pub fn advance(self: *Player, frames_elapsed: u64, q: *synth.NoteQueue) void {
         const pre_accum = self.sample_accum;
-        const post_accum = self.sample_accum + samples_elapsed;
+        const post_accum = self.sample_accum + frames_elapsed;
         self.sample_accum = post_accum;
 
-        // std.debug.print("samples_elapsed: {}, pre_accum: {}, post_accum: {}\n", .{ samples_elapsed, pre_accum, post_accum });
-        std.debug.assert(samples_elapsed < 8192);
+        // std.debug.print("frames_elapsed: {}, pre_accum: {}, post_accum: {}\n", .{ frames_elapsed, pre_accum, post_accum });
+        std.debug.assert(frames_elapsed < 8192);
 
         for (self.notes) |n| {
             // TODO check what happens when advance() is called on the latter boundary wrt <, <=
@@ -44,7 +44,7 @@ pub const Player = struct {
                 // std.debug.print("on: {}\n", .{n});
                 while (q.push(.{ .On = n.note })) {}
             }
-            // TODO what if both start and end pass in the same samples_elapsed?
+            // TODO what if both start and end pass in the same frames_elapsed?
             // might lead to a hanging note?
             if (pre_accum <= n.end and n.end < post_accum) {
                 // std.debug.print("off: {}\n", .{n});

--- a/src/sequencer.zig
+++ b/src/sequencer.zig
@@ -36,11 +36,11 @@ pub const Sequencer = struct {
     // right now only sample_rate and bpm are being read so its chill
     // but its possible to make mistakes later?
     // and like do i need to break the clean-ness just to get 2 floats in
-    pub fn advance(self: *Sequencer, ctx: *audio.Context, samples_elapsed: u64, q: *synth.NoteQueue) void {
-        // update state after samples_elapsed samples
+    pub fn advance(self: *Sequencer, ctx: *audio.Context, frames_elapsed: u64, q: *synth.NoteQueue) void {
+        // update state after frames_elapsed samples
         const samples_per_beat: u64 = @intFromFloat((60.0 / ctx.bpm) * ctx.sample_rate);
 
-        self.sample_accum += samples_elapsed;
+        self.sample_accum += frames_elapsed;
 
         if (self.sample_accum >= samples_per_beat) { // TODO >?
             self.sample_accum %= samples_per_beat;


### PR DESCRIPTION
terminology
for an audio buffer with x and y:
- "sample" means the amplitude i.e. the y value (f32)
- "frame" means the index / bin that a sample takes place in (u64)

so
my_frame: u64 = 0;
my_sample: f32 = audio[frame];